### PR TITLE
Modernize/reduce

### DIFF
--- a/src/storm-textarea.js
+++ b/src/storm-textarea.js
@@ -1,37 +1,29 @@
-
 const defaults = {
-		paddingBottom: 16,
-		events: [
-			'focus',
-			'cut',
-			'drop',
-			'keydown',
-			'resize',
-			'change'
-		]
-	},
-	StormTextarea = {
-		init() { 
-			this.settings.events.forEach(evt => this.DOMElement.addEventListener(evt, this.resize.bind(this)));
-			return this;
-		},
-		resize() {
-			this.DOMElement.style.height = 'auto';
-			this.DOMElement.style.height =  this.DOMElement.scrollHeight + this.settings.paddingBottom + 'px';
-		}
-	};
-	
-const init = (sel, opts) => {
-	let els = [].slice.call(document.querySelectorAll(sel));
-	
-	if(els.length === 0) throw new Error('Textarea cannot be initialised, no augmentable elements found');
-	
-	return els.map(el => {
-		return Object.assign(Object.create(StormTextarea), {
-			DOMElement: el,
-			settings: Object.assign({}, defaults, opts)
-		}).init();
-	});
+	events: [
+		'input'
+	]
 };
 
-export default { init };
+function resize({target}) {
+	target.style.height = 'auto';
+	target.style.height =  target.scrollHeight + 'px';
+}
+
+function listen (event) {
+	this.addEventListener(event, resize);
+}
+
+export default function (elements, settings) {
+	if (typeof elements === 'string') {
+		elements = document.querySelectorAll(elements);
+	}
+
+	if(elements.length === 0) {
+		return;
+	}
+
+	const currentSettings = Object.assign({}, defaults, settings);	
+	elements.forEach(element => {
+		currentSettings.events.forEach(listen, element);
+	});
+}

--- a/src/storm-textarea.js
+++ b/src/storm-textarea.js
@@ -14,14 +14,10 @@ export default function (elements, settings) {
 		elements = document.querySelectorAll(elements);
 	}
 
-	if(elements.length === 0) {
-		return;
-	}
-
 	const events = settings && settings.events || defaults.events;
-	for (let i = 0; i < elements.length; i++) {
-		for (let l = 0; l < events.length; i++) {
-			elements[i].addEventListener(events[l], update);
+	for (const element of elements) {
+		for (const event of events) {
+			element.addEventListener(event, update);
 		}
 		update({target: element});
 	}

--- a/src/storm-textarea.js
+++ b/src/storm-textarea.js
@@ -4,13 +4,13 @@ const defaults = {
 	]
 };
 
-function resize({target}) {
+function update({target}) {
 	target.style.height = 'auto';
 	target.style.height =  target.scrollHeight + 'px';
 }
 
 function listen (event) {
-	this.addEventListener(event, resize);
+	this.addEventListener(event, update);
 }
 
 export default function (elements, settings) {
@@ -25,5 +25,6 @@ export default function (elements, settings) {
 	const currentSettings = Object.assign({}, defaults, settings);	
 	elements.forEach(element => {
 		currentSettings.events.forEach(listen, element);
+		update({target: element});
 	});
 }

--- a/src/storm-textarea.js
+++ b/src/storm-textarea.js
@@ -22,7 +22,7 @@ export default function (elements, settings) {
 		return;
 	}
 
-	const currentSettings = Object.assign({}, defaults, settings);	
+	const events = settings && settings.events || defaults.events;	
 	elements.forEach(element => {
 		currentSettings.events.forEach(listen, element);
 		update({target: element});

--- a/src/storm-textarea.js
+++ b/src/storm-textarea.js
@@ -9,10 +9,6 @@ function update({target}) {
 	target.style.height =  target.scrollHeight + 'px';
 }
 
-function listen (event) {
-	this.addEventListener(event, update);
-}
-
 export default function (elements, settings) {
 	if (typeof elements === 'string') {
 		elements = document.querySelectorAll(elements);
@@ -22,9 +18,11 @@ export default function (elements, settings) {
 		return;
 	}
 
-	const events = settings && settings.events || defaults.events;	
-	elements.forEach(element => {
-		currentSettings.events.forEach(listen, element);
+	const events = settings && settings.events || defaults.events;
+	for (let i = 0; i < elements.length; i++) {
+		for (let l = 0; l < events.length; i++) {
+			elements[i].addEventListener(events[l], update);
+		}
 		update({target: element});
-	});
+	}
 }


### PR DESCRIPTION
Hello! I found your module to be pretty light already but I thought of some possible improvements. I understand that these heavy changes might not be pulled in so no worries in that case.

The main changes are:

- default to the single HTML5 event `input` that should handle all situations, but still allow the user to add their own _old_ events
- extract the event listener to ensure that it's only ever added once (`addEventListener` will not add the same identical function twice)
- drop `paddingBottom` as it can be just handled via CSS
- support passing a pre-existing array of elements, not just a selector
- don't throw an error if no elements are found
- update height right away, before the first input
- make `Object.assign` unnecessary